### PR TITLE
Set dockerdev tag to username

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "test:format": "prettier --check .",
     "test:lint": "yarn workspaces run test:lint",
-    "dockerdev": "docker build --build-arg AXON_VERSION=edge -t axon . && docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v wpilib-axon-volume:/usr/src/app/packages/server/data -p 3000:3000 -p 4000:4000 axon"
+    "dockerdev": "docker build --build-arg AXON_VERSION=edge -t axon:$USER . && docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v wpilib-axon-volume:/usr/src/app/packages/server/data -p 3000:3000 -p 4000:4000 axon:$USER"
   },
   "author": "",
   "license": "BSD",


### PR DESCRIPTION
By default docker uses the 'latest' tag. This means that when under development it would be possible to clobber the releaed version download. This change prevents that (unless your username is latest).