### PR TITLE
change default eval frequency to 1

### DIFF
--- a/packages/server/src/store/index.ts
+++ b/packages/server/src/store/index.ts
@@ -370,7 +370,7 @@ Project.init(
     },
     evalFrequency: {
       type: DataTypes.INTEGER.UNSIGNED,
-      defaultValue: 50
+      defaultValue: 1
     },
     percentEval: {
       type: DataTypes.FLOAT,


### PR DESCRIPTION
because the people who don't want to see every checkpoint already know what they're doing