### PR TITLE
Fix progress bar with non-one eval frequency

### DIFF
--- a/packages/server/src/mL/Trainer.ts
+++ b/packages/server/src/mL/Trainer.ts
@@ -184,8 +184,8 @@ export default class Trainer {
     const METRICSPATH = path.posix.join(this.project.directory, "metrics.json");
     if (fs.existsSync(METRICSPATH)) {
       const metrics = JSON.parse(fs.readFileSync(METRICSPATH, "utf8"));
-      this.epoch = Object.keys(metrics.precision).length;
       const jssteps: number[] = Object.keys(metrics.precision).map((s) => parseInt(s)); //we must change the metrics.json soon
+      this.epoch = jssteps.sort()[jssteps.length - 1];
       const dbsteps: number[] = (await this.project.getCheckpoints()).map((ckpt) => ckpt.step);
 
       for (const jsonstep of jssteps) {

--- a/packages/server/src/mL/Trainer.ts
+++ b/packages/server/src/mL/Trainer.ts
@@ -185,7 +185,7 @@ export default class Trainer {
     if (fs.existsSync(METRICSPATH)) {
       const metrics = JSON.parse(fs.readFileSync(METRICSPATH, "utf8"));
       const jssteps: number[] = Object.keys(metrics.precision).map((s) => parseInt(s)); //we must change the metrics.json soon
-      this.epoch = jssteps.sort()[jssteps.length - 1];
+      this.epoch = jssteps.length > 0 ? jssteps.sort()[jssteps.length - 1] : 0;
       const dbsteps: number[] = (await this.project.getCheckpoints()).map((ckpt) => ckpt.step);
 
       for (const jsonstep of jssteps) {


### PR DESCRIPTION
TO test fix, just train a model with a !=1 eval frequency, and watch the progress bar move properly.