### PR TITLE
fix video saving

### DIFF
--- a/containers/mobilenet/test/scripts/test.py
+++ b/containers/mobilenet/test/scripts/test.py
@@ -32,6 +32,7 @@ class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
 class Tester:
     def __init__(self, model_dir):
         data = parse_hyperparams.parse(model_dir + "/testparameters.json")
+        output_vid_path = data["output-vid-path"]
         self.video_path = data["test-video"]
         model_path = data["model-tar"]
         tar = tarfile.open(model_path)
@@ -48,7 +49,7 @@ class Tester:
         height = self.input_video.get(cv2.CAP_PROP_FRAME_HEIGHT)
         fps = self.input_video.get(cv2.CAP_PROP_FPS)
         fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-        self.output_video = cv2.VideoWriter("/opt/ml/model/inference.mp4", fourcc, fps, (int(width), int(height)))
+        self.output_video = cv2.VideoWriter(output_vid_path, fourcc, fps, (int(width), int(height)))
         self.server = MJPEGServer(300, 300)
 
         self.frames = 0

--- a/packages/server/src/mL/Tester.ts
+++ b/packages/server/src/mL/Tester.ts
@@ -12,6 +12,7 @@ export default class Tester {
     test: { name: "wpilib/axon-test", tag: process.env.AXON_VERSION || "edge" }
   };
 
+  private videoFilename: string;
   private container: Container;
   private streamPort: string;
   private cancelled = false;
@@ -86,7 +87,10 @@ export default class Tester {
    * @param videoPath the path to the mounted video to be used in the test
    */
   public async writeParameterFile(modelPath: string, videoPath: string): Promise<void> {
+    this.videoFilename = `${this.test.name}.mp4`;
+    const outputVidPath = path.posix.join(Docker.containerProjectPath(this.project), this.videoFilename);
     const testparameters = {
+      "output-vid-path": outputVidPath,
       "test-video": videoPath,
       "model-tar": modelPath
     };
@@ -111,7 +115,7 @@ export default class Tester {
     const ZIP_SRC = path.posix.join(this.test.directory, this.test.name);
     await mkdirp(ZIP_SRC);
 
-    const OUTPUT_VID_PATH = path.posix.join(this.project.directory, "inference.mp4");
+    const OUTPUT_VID_PATH = path.posix.join(this.project.directory, this.videoFilename);
     const CUSTOM_VID_PATH = path.posix.join(ZIP_SRC, `${this.test.name}.mp4`);
     if (!fs.existsSync(OUTPUT_VID_PATH)) Promise.reject("cant find output video");
     await fs.promises.copyFile(OUTPUT_VID_PATH, CUSTOM_VID_PATH);


### PR DESCRIPTION
fixes crash due to the server not being able to find the output video of the test container. video path is passed to the container.