### PR TITLE
Remove need to type entire dataset/project name to delete item

### DIFF
--- a/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
+++ b/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
@@ -26,7 +26,6 @@ export default function DeleteDatasetDialogButton(props: {
   handler: () => void;
 }): ReactElement {
   const [open, setOpen] = React.useState<boolean>(false);
-  const [confirmation, setConfirmation] = React.useState<string>("");
   const [deleteDataset] = useMutation(DELETE_DATASET_MUTATION);
   const apolloClient = useApolloClient();
 
@@ -38,14 +37,12 @@ export default function DeleteDatasetDialogButton(props: {
     setOpen(false);
   };
   const handleDelete = () => {
-    if (confirmation === props.dataset.name) {
-      deleteDataset({ variables: { id: props.dataset.id } }).then(() => {
-        apolloClient.resetStore().then(() => {
-          window.location.href = "/docs";
-          handleClose();
-        });
+    deleteDataset({ variables: { id: props.dataset.id } }).then(() => {
+      apolloClient.resetStore().then(() => {
+        window.location.href = "/docs";
+        handleClose();
       });
-    }
+    });
   };
 
   return (
@@ -56,8 +53,11 @@ export default function DeleteDatasetDialogButton(props: {
       <Dialog onClose={handleClose} open={open}>
         <DialogTitle>Confirm Dataset Deletion</DialogTitle>
         <DialogContent dividers>
-          <p> Please confirm dataset deletion by typing &ldquo;{props.dataset.name}&rdquo; </p>
-          <TextField onChange={(event) => setConfirmation(event.target.value)} autoFocus margin="dense" fullWidth />
+          <p>
+            {" "}
+            Are you sure you want to permanently delete dataset &ldquo;{props.dataset.name}&rdquo;? This action cannot
+            be undone.{" "}
+          </p>
         </DialogContent>
         <DialogActions>
           <Button autoFocus variant={"contained"} onClick={handleClose}>

--- a/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
+++ b/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
@@ -53,11 +53,10 @@ export default function DeleteDatasetDialogButton(props: {
       <Dialog onClose={handleClose} open={open}>
         <DialogTitle>Confirm Dataset Deletion</DialogTitle>
         <DialogContent dividers>
-          <p>
-            {" "}
+          <Typography>
             Are you sure you want to permanently delete dataset &ldquo;{props.dataset.name}&rdquo;? This action cannot
-            be undone.{" "}
-          </p>
+            be undone.
+          </Typography>
         </DialogContent>
         <DialogActions>
           <Button autoFocus variant={"contained"} onClick={handleClose}>

--- a/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
+++ b/packages/client/src/components/dataset/DeleteDatasetDialog.tsx
@@ -1,15 +1,6 @@
 import React, { ReactElement } from "react";
 import { useApolloClient, useMutation } from "@apollo/client";
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  MenuItem,
-  TextField,
-  Typography
-} from "@material-ui/core";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Typography } from "@material-ui/core";
 import gql from "graphql-tag";
 import { GetDataset_dataset } from "./__generated__/GetDataset";
 

--- a/packages/client/src/components/project/DeleteProjectDialog.tsx
+++ b/packages/client/src/components/project/DeleteProjectDialog.tsx
@@ -53,11 +53,10 @@ export default function DeleteProjectDialogButton(props: {
       <Dialog onClose={handleClose} open={open}>
         <DialogTitle>Confirm Project Deletion</DialogTitle>
         <DialogContent dividers>
-          <p>
-            {" "}
+          <Typography>
             Are you sure you want to permanently delete project &ldquo;{props.project.name}&rdquo;? This action cannot
-            be undone.{" "}
-          </p>
+            be undone.
+          </Typography>
         </DialogContent>
         <DialogActions>
           <Button autoFocus variant={"contained"} onClick={handleClose}>

--- a/packages/client/src/components/project/DeleteProjectDialog.tsx
+++ b/packages/client/src/components/project/DeleteProjectDialog.tsx
@@ -1,13 +1,4 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  MenuItem,
-  TextField,
-  Typography
-} from "@material-ui/core";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Typography } from "@material-ui/core";
 import { useApolloClient, useMutation } from "@apollo/client";
 import React, { ReactElement } from "react";
 import gql from "graphql-tag";

--- a/packages/client/src/components/project/DeleteProjectDialog.tsx
+++ b/packages/client/src/components/project/DeleteProjectDialog.tsx
@@ -26,7 +26,6 @@ export default function DeleteProjectDialogButton(props: {
   handler: () => void;
 }): ReactElement {
   const [open, setOpen] = React.useState<boolean>(false);
-  const [confirmation, setConfirmation] = React.useState<string>("");
   const [deleteProject] = useMutation(DELETE_PROJECT_MUTATION);
   const apolloClient = useApolloClient();
 
@@ -38,14 +37,12 @@ export default function DeleteProjectDialogButton(props: {
     setOpen(false);
   };
   const handleDelete = () => {
-    if (confirmation === props.project.name) {
-      deleteProject({ variables: { id: props.project.id } }).then(() => {
-        apolloClient.resetStore().then(() => {
-          window.location.href = "/docs";
-          handleClose();
-        });
+    deleteProject({ variables: { id: props.project.id } }).then(() => {
+      apolloClient.resetStore().then(() => {
+        window.location.href = "/docs";
+        handleClose();
       });
-    }
+    });
   };
 
   return (
@@ -56,8 +53,11 @@ export default function DeleteProjectDialogButton(props: {
       <Dialog onClose={handleClose} open={open}>
         <DialogTitle>Confirm Project Deletion</DialogTitle>
         <DialogContent dividers>
-          <p> Please confirm project deletion by typing &ldquo;{props.project.name}&rdquo; </p>
-          <TextField onChange={(event) => setConfirmation(event.target.value)} autoFocus margin="dense" fullWidth />
+          <p>
+            {" "}
+            Are you sure you want to permanently delete project &ldquo;{props.project.name}&rdquo;? This action cannot
+            be undone.{" "}
+          </p>
         </DialogContent>
         <DialogActions>
           <Button autoFocus variant={"contained"} onClick={handleClose}>


### PR DESCRIPTION
This process has become tedious, especially with longer dataset names (if the name of the dataset is the same as say, an iPhone video name). Confirmation dialog still exists.