### PR TITLE
Fix xs for dataset stats

### DIFF
--- a/packages/client/src/components/dataset/Dataset.tsx
+++ b/packages/client/src/components/dataset/Dataset.tsx
@@ -164,7 +164,7 @@ export default function Dataset(props: { id: string }): ReactElement {
         </Menu>
       </Toolbar>
       <Grid container spacing={3} style={{ paddingLeft: 50 }}>
-        <Grid item>
+        <Grid item xs={2}>
           <Card className={classes.card}>
             <Grid container spacing={3}>
               <Grid item xs={12}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24625614/125676149-059adbfb-b2ba-4c84-995c-e62ed9cfa08c.png)

I like having the stats on the left of the images, instead of above.

Closes #272 